### PR TITLE
feat: add export gradient text as image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## 📝 Overview
 
 Gradient Text Pro is a powerful web tool for creating stunning CSS gradient text effects with real-time preview.
-Easily customize linear, radial, and conic gradients with multiple color stops, modern OKLCH color space support, typography settings, and instant CSS code generation.
+Easily customize linear, radial, and conic gradients with multiple color stops, modern OKLCH color space support, typography settings, instant CSS code generation, and high-quality image export.
 Perfect for creating eye-catching headlines, logos, and web interfaces with professional gradient text designs that leverage cutting-edge color technology.
 
 ## ✨ Features
@@ -33,6 +33,7 @@ Perfect for creating eye-catching headlines, logos, and web interfaces with prof
 - 🔤 Typography settings: font size, weight, letter spacing, and line height
 - 👀 Real-time preview of gradient text designs
 - 📋 One-click CSS code generation and copy
+- 🖼️ High-quality image export in PNG, WebP, and SVG formats with customizable scale
 - 🎯 Preset library with popular gradient combinations
 - 🌓 Light/Dark theme toggle
 - 📱 Responsive UI for mobile and desktop
@@ -45,8 +46,9 @@ Perfect for creating eye-catching headlines, logos, and web interfaces with prof
 3. Select gradient type (linear, radial, or conic) and adjust the angle
 4. Choose between HEX (classic) or OKLCH (modern) color format for optimal results
 5. Fine-tune typography settings like font size, weight, and spacing
-6. Copy the generated CSS code with one click
-7. Use the code directly in your web projects
+6. Copy the generated CSS code with one click or export as high-quality images
+7. For image export, select format (PNG/WebP/SVG) and scale (1x-3x) then click export
+8. Use the code or images directly in your web projects
 
 ## 💻 Technology Stack
 

--- a/app/components/ContentPanel.vue
+++ b/app/components/ContentPanel.vue
@@ -6,6 +6,7 @@ const DISABLED_CLIP = {
   WebkitBackgroundClip: undefined,
 } as const;
 
+const previewTextEl = useTemplateRef('previewText');
 const showFullGradient = ref(false);
 
 const previewTextStyle = computed(() => showFullGradient.value
@@ -14,10 +15,10 @@ const previewTextStyle = computed(() => showFullGradient.value
 </script>
 
 <template>
-  <PanelContainer class="flex h-full flex-col gap-8 overflow-hidden p-4">
+  <PanelContainer class="flex h-full flex-col gap-6 overflow-hidden p-4">
     <section aria-label="Gradient text preview panel" class="flex size-full min-h-0 flex-1 flex-col rounded-lg bg-elevated">
       <div class="flex size-full flex-col items-center justify-start overflow-y-auto p-3">
-        <span :style="previewTextStyle" class="my-auto text-center whitespace-pre-wrap">
+        <span ref="previewText" :style="previewTextStyle" class="my-auto text-center whitespace-pre-wrap">
           {{ text || 'Gradient Text Pro' }}
         </span>
       </div>
@@ -37,6 +38,9 @@ const previewTextStyle = computed(() => showFullGradient.value
       </div>
     </section>
 
-    <OutputCode title="CSS Output" :code="cssOutput" class="h-40 lg:h-52" />
+    <div class="space-y-3">
+      <OutputCode title="CSS Output" :code="cssOutput" class="h-36 lg:h-44" />
+      <ImageExportControls :target="previewTextEl" />
+    </div>
   </PanelContainer>
 </template>

--- a/app/components/ImageExportControls.vue
+++ b/app/components/ImageExportControls.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+const props = defineProps<{
+  target: HTMLElement | null;
+}>();
+
+const { downloadAsImage } = useScreenshot();
+
+const scaleItems = [
+  { label: '1x', value: 1 },
+  { label: '1.5x', value: 1.5 },
+  { label: '2x', value: 2 },
+  { label: '3x', value: 3 }
+];
+
+const formatItems = [
+  { label: 'PNG', value: 'png' },
+  { label: 'WEBP', value: 'webp' },
+  { label: 'SVG', value: 'svg' },
+] as const satisfies { label: string; value: ScreenshotFormat }[];
+
+const scale = ref(1);
+const format = ref<ScreenshotFormat>('png');
+
+const handleExport = async () => {
+  if (!props.target) return;
+
+  await downloadAsImage(props.target, { format: format.value, scale: scale.value });
+};
+</script>
+
+<template>
+  <div class="flex items-center justify-end gap-2">
+    <UTooltip text="Select image scale" arrow>
+      <USelect
+        v-model="scale"
+        :items="scaleItems"
+        size="sm"
+        aria-label="Select image scale"
+        class="w-20"
+      />
+    </UTooltip>
+
+    <UTooltip text="Select image format" arrow>
+      <USelect
+        v-model="format"
+        :items="formatItems"
+        size="sm"
+        aria-label="Select image format"
+        class="w-24"
+      />
+    </UTooltip>
+
+    <UButton
+      label="Export as image"
+      size="sm"
+      icon="i-lucide-download"
+      variant="outline"
+      @click="handleExport"
+    />
+  </div>
+</template>

--- a/app/composables/useScreenshot.ts
+++ b/app/composables/useScreenshot.ts
@@ -1,0 +1,106 @@
+import { domToPng, domToSvg, domToWebp } from 'modern-screenshot';
+
+export type ScreenshotFormat = 'png' | 'webp' | 'svg';
+
+export interface ScreenshotOptions {
+  /**
+   * Image format
+   * @default 'png'
+   */
+  format?: ScreenshotFormat;
+
+  /**
+   * Image scale factor
+   * @default 1
+   */
+  scale?: number;
+
+  /**
+   * Background color
+   * @default transparent
+   */
+  backgroundColor?: string;
+}
+
+export interface ScreenshotResult {
+  /**
+   * Base64 data URL
+   */
+  dataUrl: string;
+
+  /**
+   * Generated filename
+   */
+  filename: string;
+}
+
+export function useScreenshot() {
+  const isLoading = ref(false);
+  const error = shallowRef<unknown>();
+
+  const formatHandlers = {
+    png: { capture: domToPng, extension: 'png' },
+    webp: { capture: domToWebp, extension: 'webp' },
+    svg: { capture: domToSvg, extension: 'svg' },
+  } as const;
+
+  /**
+   * Capture DOM element as image in specified format
+   * @param element - HTML element to capture
+   * @param options - Screenshot options
+   * @returns Promise resolving to screenshot result
+   */
+  async function captureElement(element: HTMLElement, options: ScreenshotOptions): Promise<ScreenshotResult> {
+    const { format = 'png', ...handlerOptions } = options;
+    const handler = formatHandlers[format];
+
+    const dataUrl = await handler.capture(element, handlerOptions);
+    const filename = `gradient-${Date.now()}.${handler.extension}`;
+
+    return {
+      dataUrl,
+      filename,
+    };
+  }
+
+  /**
+   * Download image result as file
+   * @param result - Screenshot result containing data URL and filename
+   */
+  function downloadImage(result: ScreenshotResult): void {
+    const link = document.createElement('a');
+    link.download = result.filename;
+    link.href = result.dataUrl;
+    link.style.display = 'none';
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
+
+  /**
+   * Capture DOM element and download as image file
+   * @param element - HTML element to capture
+   * @param options - Screenshot options (format defaults to 'png')
+   * @returns Promise that resolves when download is complete
+   */
+  async function downloadAsImage(element: HTMLElement, options: ScreenshotOptions = {}): Promise<void> {
+    isLoading.value = true;
+    error.value = null;
+
+    try {
+      const result = await captureElement(element, options);
+      downloadImage(result);
+    } catch (err) {
+      error.value = err;
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  return {
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    downloadAsImage,
+  };
+}

--- a/app/docs/guide.mdc
+++ b/app/docs/guide.mdc
@@ -12,6 +12,7 @@ This is a unique gradient text design tool that perfectly balances visual appeal
 - 🎚️ **Advanced Gradient Control**: Easily customize gradient direction, color stops, and positions to create complex text effects.
 - 🎨 **Modern Color Format Support**: Choose between traditional HEX colors or modern OKLCH for smoother, more natural gradients.
 - 📝 **CSS Code Generation**: Copy the generated CSS with a single click and use it immediately in your projects.
+- 🖼️ **Image Export**: Export your gradient text as high-quality PNG, WebP, or SVG images with customizable scale options.
 - 🎨 **Preset Selection**: Choose from popular gradient text presets for quick results and efficient workflow.
 - 🔤 **Typography Customization**: Fine-tune font size, weight, letter spacing, and line height for perfect text rendering.
 - 🌗 **Dark/Light Theme Switching**: Change the UI to match your workspace or personal preference.
@@ -23,15 +24,19 @@ This is a unique gradient text design tool that perfectly balances visual appeal
 4. Choose between HEX (classic) or OKLCH (modern) color format for optimal gradient appearance.
 5. Fine-tune typography settings like font size, weight, letter spacing, and line height.
 6. Check the real-time preview and make adjustments as needed.
-7. Click the "Copy CSS Code" button to instantly get the generated code.
-8. Switch between dark and light themes to suit your environment.
+7. Click the "Copy CSS Code" button to instantly get the generated code, or export as image using the export controls.
+8. For image export, select your preferred format (PNG, WebP, SVG) and scale (1x, 1.5x, 2x, 3x), then click "Export as image".
+9. Switch between dark and light themes to suit your environment.
 
 #### Frequently Asked Questions (FAQ)
 ❓ **Q. What kind of websites can I use this for?**
 A. You can use gradient text for any text element—headlines, logos, buttons, navigation, banners, and more. It's especially effective for creating eye-catching titles and branding elements.
 
 💻 **Q. What format is the generated code?**
-A. The output is standard CSS with gradient properties, available in both traditional HEX format and modern OKLCH color space. OKLCH provides smoother, more natural gradients with better perceptual uniformity. The code includes all necessary properties for cross-browser compatibility.
+A. The output is standard CSS with gradient properties, available in both traditional HEX format and modern OKLCH color space. OKLCH provides smoother, more natural gradients with better perceptual uniformity. The code includes all necessary properties for cross-browser compatibility. You can also export your gradient text as high-quality images in PNG, WebP, or SVG formats.
+
+🖼️ **Q. What image formats are supported for export?**
+A. You can export your gradient text as PNG (best for general use), WebP (smaller file size with good quality), or SVG (vector format, scalable). Each format also supports multiple scale options (1x, 1.5x, 2x, 3x) for different display densities and use cases.
 
 🎨 **Q. What's the difference between HEX and OKLCH color formats?**
 A. HEX is the classic format that's widely supported and familiar to most developers. OKLCH is a modern color space that provides more natural gradient transitions, better color uniformity, and smoother blending. Choose HEX for maximum compatibility or OKLCH for the best visual results.
@@ -40,10 +45,10 @@ A. HEX is the classic format that's widely supported and familiar to most develo
 A. Yes! It's fully responsive, so you can use it comfortably on PC, smartphone, or tablet.
 
 🆚 **Q. How is this different from other gradient text generators?**
-A. Gradient Text Pro offers advanced customization with multiple color stops, precise angle control, comprehensive typography settings, modern OKLCH color space support, preset selection, real-time preview, and theme switching—features chosen for real-world usability. Its ease of use, design flexibility, and cutting-edge color technology set it apart.
+A. Gradient Text Pro offers advanced customization with multiple color stops, precise angle control, comprehensive typography settings, modern OKLCH color space support, preset selection, high-quality image export in multiple formats, real-time preview, and theme switching—features chosen for real-world usability. Its ease of use, design flexibility, cutting-edge color technology, and versatile export options set it apart.
 
 ---
-Gradient Text Pro is trusted by many users searching for "CSS gradient text," "gradient text generator," "web design tool," "text gradient CSS," and "typography design." Try it in your next project!
+Gradient Text Pro is trusted by many users searching for "CSS gradient text," "gradient text generator," "web design tool," "text gradient CSS," "gradient text image export," and "typography design." Try it in your next project!
 
 Gradient Text Pro is developed and released as OSS (Open Source Software).
 See the GitHub repository for details: [GitHub - gradient-text-pro](https://github.com/k-urtica/gradient-text-pro)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@vueuse/core": "13.9.0",
     "@vueuse/nuxt": "13.9.0",
     "culori": "4.0.2",
+    "modern-screenshot": "^4.6.6",
     "motion-v": "1.7.1",
     "nuxt": "4.1.2",
     "remark-breaks": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@vueuse/core": "13.9.0",
     "@vueuse/nuxt": "13.9.0",
     "culori": "4.0.2",
-    "modern-screenshot": "^4.6.6",
+    "modern-screenshot": "4.6.6",
     "motion-v": "1.7.1",
     "nuxt": "4.1.2",
     "remark-breaks": "4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         specifier: 4.0.2
         version: 4.0.2
       modern-screenshot:
-        specifier: ^4.6.6
+        specifier: 4.6.6
         version: 4.6.6
       motion-v:
         specifier: 1.7.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       culori:
         specifier: 4.0.2
         version: 4.0.2
+      modern-screenshot:
+        specifier: ^4.6.6
+        version: 4.6.6
       motion-v:
         specifier: 1.7.1
         version: 1.7.1(@vueuse/core@13.9.0(vue@3.5.21(typescript@5.9.2)))(vue@3.5.21(typescript@5.9.2))
@@ -4497,6 +4500,9 @@ packages:
 
   mocked-exports@0.1.1:
     resolution: {integrity: sha512-aF7yRQr/Q0O2/4pIXm6PZ5G+jAd7QS4Yu8m+WEeEHGnbo+7mE36CbLSDQiXYV8bVL3NfmdeqPJct0tUlnjVSnA==}
+
+  modern-screenshot@4.6.6:
+    resolution: {integrity: sha512-8tF0xEpe7yx37mK95UcIghSCWYeu628K2hLJl+ZNY2ANmRzYLlRLpquPHAQcL8keF6BoeEzTEw4GrgmUpGuZ8w==}
 
   motion-dom@12.23.12:
     resolution: {integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==}
@@ -11297,6 +11303,8 @@ snapshots:
       ufo: 1.6.1
 
   mocked-exports@0.1.1: {}
+
+  modern-screenshot@4.6.6: {}
 
   motion-dom@12.23.12:
     dependencies:


### PR DESCRIPTION
This pull request adds a major new feature: high-quality image export for gradient text, allowing users to export their designs as PNG, WebP, or SVG images with customizable scale. The implementation includes UI controls, composables, documentation updates, and dependency additions. Below are the most important changes grouped by theme.

**Feature Implementation: Image Export**

* Added new `ImageExportControls.vue` component with UI for selecting image format (PNG/WebP/SVG) and scale (1x–3x), and exporting the gradient text preview as an image.
* Introduced `useScreenshot.ts` composable to handle DOM element capture and image file download using the `modern-screenshot` library.
* Integrated image export controls into the main panel UI (`ContentPanel.vue`), wiring up the preview text element as the export target and adjusting layout for new controls. [[1]](diffhunk://#diff-2eea9bf73f1f5c897479cf9f79d469d6f2a0c341bb1d261d4e1f790e31288470R9) [[2]](diffhunk://#diff-2eea9bf73f1f5c897479cf9f79d469d6f2a0c341bb1d261d4e1f790e31288470L17-R21) [[3]](diffhunk://#diff-2eea9bf73f1f5c897479cf9f79d469d6f2a0c341bb1d261d4e1f790e31288470L40-R44)

**Documentation and Marketing Updates**

* Updated `README.md` and user guide (`guide.mdc`) to highlight the new image export feature, including supported formats, scale options, and instructions for use. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R51) [[4]](diffhunk://#diff-b2709669d69e6e111fd3469c6bc3beefd95d32cdc311e3b1e1e8d7cbfc411492R15) [[5]](diffhunk://#diff-b2709669d69e6e111fd3469c6bc3beefd95d32cdc311e3b1e1e8d7cbfc411492L26-R39) [[6]](diffhunk://#diff-b2709669d69e6e111fd3469c6bc3beefd95d32cdc311e3b1e1e8d7cbfc411492L43-R51)

**Dependency Management**

* Added `modern-screenshot` as a new dependency in `package.json` and updated `pnpm-lock.yaml` to include the package in the lockfile and snapshot sections. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R22) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR29-R31) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4504-R4506) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11307-R11308)