### PR TITLE
feat: update gradient presets

### DIFF
--- a/app/components/ContentPanel.vue
+++ b/app/components/ContentPanel.vue
@@ -1,16 +1,11 @@
 <script setup lang="ts">
 const { text, textStyle, cssOutput } = useGradient();
 
-const DISABLED_CLIP = {
-  backgroundClip: undefined,
-  WebkitBackgroundClip: undefined,
-} as const;
-
 const previewTextEl = useTemplateRef('previewText');
 const showFullGradient = ref(false);
 
 const previewTextStyle = computed(() => showFullGradient.value
-  ? { ...textStyle.value, ...DISABLED_CLIP }
+  ? { ...textStyle.value, ...NO_TEXT_CLIP }
   : textStyle.value);
 </script>
 

--- a/app/components/editor/GradientPresetList.vue
+++ b/app/components/editor/GradientPresetList.vue
@@ -9,6 +9,8 @@ const emit = defineEmits<{
   selectPreset: [preset: GradientPreset];
 }>();
 
+const showSwatch = ref(false);
+
 const { getPresetPreviewStyle } = useGradientPresets();
 
 const handlePresetClick = (preset: GradientPreset) => {
@@ -18,13 +20,27 @@ const handlePresetClick = (preset: GradientPreset) => {
 
 <template>
   <div>
-    <BaseIconText
-      as="h4"
-      icon="i-lucide-sparkles"
-      class="mb-2 text-sm"
-    >
-      Presets
-    </BaseIconText>
+    <div class="mb-2 flex items-center justify-between">
+      <BaseIconText
+        as="h4"
+        icon="i-lucide-sparkles"
+        class="text-sm"
+      >
+        Presets
+      </BaseIconText>
+
+      <UTooltip text="Toggle preset preview: text or swatch" arrow>
+        <span>
+          <USwitch
+            v-model="showSwatch"
+            checked-icon="i-lucide-swatch-book"
+            unchecked-icon="i-lucide-type"
+            size="xs"
+            aria-label="Toggle preset preview: text or swatch"
+          />
+        </span>
+      </UTooltip>
+    </div>
 
     <div class="overflow-hidden rounded-lg border border-default">
       <ul
@@ -39,13 +55,15 @@ const handlePresetClick = (preset: GradientPreset) => {
           <UButton
             variant="soft"
             size="sm"
-            class="flex size-full flex-col gap-1.5 ring-1 ring-muted/70"
+            class="flex size-full h-16 flex-col gap-1.5 ring-1 ring-muted/70"
             :aria-label="`Apply preset: ${preset.label}`"
             @click="handlePresetClick(preset)"
           >
             <div
-              class="size-4 text-xs font-bold"
-              :style="{ ...getPresetPreviewStyle(preset) }"
+              aria-hidden="true"
+              class="text-xs font-bold"
+              :class="[showSwatch ? 'h-4 w-full rounded-sm' : 'size-4']"
+              :style="{ ...getPresetPreviewStyle(preset), ...(showSwatch ? NO_TEXT_CLIP : {}) }"
             >
               Aa
             </div>

--- a/app/composables/useGradient.ts
+++ b/app/composables/useGradient.ts
@@ -6,14 +6,13 @@ export interface GradientStop {
   /** Position of the gradient stop (0-100) */
   position: number;
 }
-export interface GradientSettings {
-  /** Type of gradient: linear, radial, or conic */
-  type: GradientType;
-  /** Angle of the gradient (for linear and conic gradients) */
-  angle: number;
-  /** Gradient stops */
-  stops: GradientStop[];
-}
+
+/**
+ * Gradient settings.
+ */
+export type GradientSettings =
+  | { type: Extract<GradientType, 'radial'>; angle?: number; stops: GradientStop[] } |
+  { type: Extract<GradientType, 'linear' | 'conic'>; angle: number; stops: GradientStop[] };
 
 export interface FontSettings {
   /** Font size */
@@ -91,8 +90,6 @@ export function useGradient() {
         return `radial-gradient(circle, ${stopsString})`;
       case GRADIENT_TYPES.conic:
         return `conic-gradient(from ${settings.angle}deg, ${stopsString})`;
-      default:
-        return `linear-gradient(${settings.angle}deg, ${stopsString})`;
     }
   };
 

--- a/app/constants/gradient.ts
+++ b/app/constants/gradient.ts
@@ -31,3 +31,9 @@ export const COLOR_FORMAT_ITEMS = [
   { label: 'Hex', value: COLOR_FORMATS.hex },
   { label: 'OKLCH', value: COLOR_FORMATS.oklch }
 ];
+
+/** No text clipping styles */
+export const NO_TEXT_CLIP = {
+  backgroundClip: undefined,
+  WebkitBackgroundClip: undefined,
+} as const;

--- a/app/constants/presets.ts
+++ b/app/constants/presets.ts
@@ -58,7 +58,6 @@ export const GRADIENT_PRESETS: GradientPreset[] = [
     label: 'Golden Hour',
     gradient: {
       type: 'radial',
-      angle: 0,
       stops: [
         { id: 'stop1', color: '#fef3c7', position: 0 },
         { id: 'stop2', color: '#fbbf24', position: 50 },
@@ -154,12 +153,52 @@ export const GRADIENT_PRESETS: GradientPreset[] = [
     label: 'Ice Crystal',
     gradient: {
       type: 'radial',
-      angle: 0,
       stops: [
         { id: 'stop1', color: '#f0f9ff', position: 0 },
         { id: 'stop2', color: '#e0f2fe', position: 30 },
         { id: 'stop3', color: '#0ea5e9', position: 70 },
         { id: 'stop4', color: '#0369a1', position: 100 }
+      ]
+    }
+  },
+  {
+    id: 'solar-flare',
+    label: 'Solar Flare',
+    gradient: {
+      type: 'radial',
+      stops: [
+        { id: 'stop1', color: '#fef3c7', position: 0 },
+        { id: 'stop2', color: '#f59e0b', position: 40 },
+        { id: 'stop3', color: '#ea580c', position: 70 },
+        { id: 'stop4', color: '#dc2626', position: 100 }
+      ]
+    }
+  },
+  {
+    id: 'galaxy-spiral',
+    label: 'Galaxy Spiral',
+    gradient: {
+      type: 'conic',
+      angle: 90,
+      stops: [
+        { id: 'stop1', color: '#1e1b4b', position: 0 },
+        { id: 'stop2', color: '#6366f1', position: 25 },
+        { id: 'stop3', color: '#8b5cf6', position: 50 },
+        { id: 'stop4', color: '#ec4899', position: 75 },
+        { id: 'stop5', color: '#1e1b4b', position: 100 }
+      ]
+    }
+  },
+  {
+    id: 'forest-mist',
+    label: 'Forest Mist',
+    gradient: {
+      type: 'radial',
+      stops: [
+        { id: 'stop1', color: '#d1fae5', position: 0 },
+        { id: 'stop2', color: '#6ee7b7', position: 30 },
+        { id: 'stop3', color: '#10b981', position: 70 },
+        { id: 'stop4', color: '#064e3b', position: 100 }
       ]
     }
   }


### PR DESCRIPTION
This pull request introduces improvements to gradient preset handling, preset preview UI, and type safety for gradient settings. It adds new gradient presets, refines the way gradient settings are typed (especially for radial gradients), and enhances the user interface by allowing users to toggle between text and swatch previews for presets. Additionally, it cleans up the code by extracting shared styles and ensuring presets use the correct gradient settings.

**Gradient Preset Enhancements**
* Added three new gradient presets: `Solar Flare`, `Galaxy Spiral`, and `Forest Mist`, expanding the variety of available gradients.
* Removed unnecessary `angle: 0` properties from radial gradient presets for consistency with updated type definitions.

**Type Safety and Code Consistency**
* Changed `GradientSettings` from an interface to a discriminated union type, making `angle` optional for radial gradients and required for linear/conic gradients, improving type safety and clarity.
* Updated gradient CSS generation logic to use the correct gradient type and angle, removing the default linear-gradient fallback.

**UI and Usability Improvements**
* Added a toggle switch in `GradientPresetList.vue` to allow users to preview presets as either text or swatch, improving usability and accessibility.
* Extracted the `NO_TEXT_CLIP` style constant to a shared location for consistent use and easier maintenance. [[1]](diffhunk://#diff-fa2fcaa7228b3feafed326eadd22a3f666a228406c4f2985bbf044f9cb1771deR34-R39) [[2]](diffhunk://#diff-2eea9bf73f1f5c897479cf9f79d469d6f2a0c341bb1d261d4e1f790e31288470L4-R8)
* Updated preset preview rendering to use the toggle state and shared style constant, ensuring correct visual representation. [[1]](diffhunk://#diff-47f0cd160b053541bbd2e6434f09d5596a7955816749fbb9da5fd969c55f1042L42-R66) [[2]](diffhunk://#diff-47f0cd160b053541bbd2e6434f09d5596a7955816749fbb9da5fd969c55f1042R12-R13)